### PR TITLE
Improve some test stuffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,7 @@ cache:
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
-
-allow_failures:
-  - php: 7.4snapshot
+  - 7.4
 
 before_script:
   - composer self-update

--- a/tests/cli/CommandLineTest.php
+++ b/tests/cli/CommandLineTest.php
@@ -46,7 +46,7 @@ class CommandLineTest extends TestCase
         $res = $commandLine->getCommand();
 
         $this->assertEquals('echo \'foo\'', $res);
-        $this->assertEquals('echo \'foo\'', (string)$commandLine);
+        $this->assertEquals('echo \'foo\'', (string) $commandLine);
     }
 
     /**

--- a/tests/cli/UtilTest.php
+++ b/tests/cli/UtilTest.php
@@ -241,7 +241,7 @@ class UtilTest extends TestCase
         $decoratedText = Util::formatWithAsterisk($plainText);
 
         $this->assertEquals(72, strlen(trim($decoratedText)));
-        $this->assertTrue(strpos($decoratedText, '*') !== false);
+        $this->assertStringContainsString('*', $decoratedText);
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Using the `php-7.4` version test during Travis CI build.
- To be consistency, using the `(string) ` with white space before variable.
- Using the `assertStringContainsString` assertion to assert specific needle string is existed on specific haystack string.