### PR TITLE
Improve code stuffs

### DIFF
--- a/src/Processor/Symfony.php
+++ b/src/Processor/Symfony.php
@@ -11,7 +11,6 @@
 
 namespace SebastianFeldmann\Cli\Processor;
 
-use RuntimeException;
 use SebastianFeldmann\Cli\Command\Result;
 use SebastianFeldmann\Cli\Processor;
 use Symfony\Component\Process\Process;
@@ -35,7 +34,7 @@ class Symfony implements Processor
      */
     public function run(string $cmd, array $acceptableExitCodes = [0]): Result
     {
-        $process = method_exists('Symfony\Component\Process\Process', 'fromShellCommandline')
+        $process = method_exists(Process::class, 'fromShellCommandline')
                  ? Process::fromShellCommandline($cmd)
                  : new Process([$cmd]);
 

--- a/tests/cli/UtilTest.php
+++ b/tests/cli/UtilTest.php
@@ -33,7 +33,7 @@ class UtilTest extends TestCase
     /**
      * Backup $_SERVER settings.
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         self::$server = $_SERVER;
     }
@@ -41,7 +41,7 @@ class UtilTest extends TestCase
     /**
      * Restore $_SERVER settings
      */
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         $_SERVER = self::$server;
     }


### PR DESCRIPTION
# Changed log
- Removing the `RuntimeException` because it's unused.
- Using the `::class` magic method call to replace `Symfony\Component\Process\Process` class string.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/8.5/fixtures.html?highlight=fixtures), it should be `protected setUp` and `protected tearDown` methods.