### PR TITLE
Fix windows unrecognized command on directory with empty space

### DIFF
--- a/src/Command/Executable.php
+++ b/src/Command/Executable.php
@@ -12,6 +12,7 @@
 namespace SebastianFeldmann\Cli\Command;
 
 use SebastianFeldmann\Cli\Command;
+use SebastianFeldmann\Cli\Util;
 
 /**
  * Class Executable
@@ -59,7 +60,7 @@ class Executable implements Command
      */
     public function __construct(string $cmd, array $exitCodes = [0])
     {
-        $this->cmd                 = $cmd;
+        $this->cmd                 = ! defined('PHP_WINDOWS_VERSION_BUILD') ? $cmd : Util::escapeSpacesOnWindows($cmd);
         $this->acceptableExitCodes = $exitCodes;
     }
 

--- a/src/Util.php
+++ b/src/Util.php
@@ -312,4 +312,15 @@ abstract class Util
         }
         rmdir($dir);
     }
+
+    /**
+     * Escapes 'unescaped' space sequences on Windows.
+     * i.e: 'E:/Program Files' escaped to 'E:/Program^ Files'
+     * @param string $cmd
+     * @return string
+     */
+    public static function escapeSpacesOnWindows(string $cmd): string
+    {
+        return preg_replace('/(?<!\^)( )/', '^ ', $cmd);
+    }
 }

--- a/tests/cli/UtilTest.php
+++ b/tests/cli/UtilTest.php
@@ -279,6 +279,28 @@ class UtilTest extends TestCase
     }
 
     /**
+     * Tests Util::escapeSpacesOnWindows
+     * @dataProvider providerWindowsPathsCases
+     */
+    public function testEscapeSpacesOnWindows(string $expected, string $cmd): void
+    {
+        self::assertSame($expected, Util::escapeSpacesOnWindows($cmd));
+    }
+
+    /**
+     * @return string[][]
+     */
+    public function providerWindowsPathsCases(): array
+    {
+        $escapedCommand = 'E:/Program^ Files/';
+        $unEscapedCommand = 'E:/Program Files/';
+        return [
+            'test already escaped sequence' => [$escapedCommand, $escapedCommand],
+            'test unescaped sequence' => [$escapedCommand, $unEscapedCommand],
+        ];
+    }
+
+    /**
      * Create some temp command
      *
      * @param  string $cmd


### PR DESCRIPTION
When trying to execute a command on a Windows machine, the processing of the command fails with the command unrecognized due to not properly escaping white spaces.

For example, the following would fail due to having a `space` character in one of the parent directories.
```
"C:\Program Files\tar.exe -zcf "some_file.tar.gz" -C "C:\" "some_directory"
```

This PR replaces every `space` character in command with an escaping sequence `^ `.